### PR TITLE
Remove 'validation' & PHP functionality for now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 jQuery Conditions
 =================
 
-**jQuery Conditions** is a new project aiming at providing conditional rule handling for form fields including show/hide/message/validation handling.
+**jQuery Conditions** is a new project aiming at providing conditional rule handling for form fields including show/hide/message.
 
 # Roadmap
 
@@ -12,7 +12,6 @@ jQuery Conditions
     * Show this field
     * Hide this field
     * Show a message
-    * Show an error message (for validation, blocks form submit)
 * **What element selector to base logic off of**
 * **Comparison operator**
     * `=`
@@ -36,4 +35,3 @@ jQuery Conditions
     * *Value to check*
         * Single for `=` `!=` `>` `>=` `<` `<=` `LIKE` `NOT LIKE` `REGEX MATCH` `REGEX NEGATIVE MATCH`
         * Multiple values for `IN` `NOT IN` `BETWEEN` `NOT BETWEEN`
-* **PHP functions to output show/hide/validation CSS and messaging**


### PR DESCRIPTION
If the feature-set of the conditions plugin is to offer conditional related functionality then validation should be handled elsewhere. There are already several validation plugin projects that might clash with this functionality that users may already have in use in their projects.
- http://jqueryvalidation.org/
- https://github.com/posabsolute/jQuery-Validation-Engine

Therefore, I would at least at first stay concerned with just the conditional core and then once that is established if there is good reason then build in some kind of callback or plugin to plugin notification system that would allow an existing validation plugin to intercept potential validation use-cases from the conditions plugin, without the conditions plugin taking over that functionality.

I also would keep it sterile from PHP. If your goal is merely to extend Pods then I can see why you would add in the PHP related functionality, but if you are thinking more universally -- to allow users to use it in whatever setup they have, then adding in PHP is for one language use case (what about Python, Ruby, etc.?) At least at first, keeping things simple and strictly associated with just conditions as they are related to jQuery's role might be best.

Just my two-cents. :)
